### PR TITLE
chore(ci): add initial github actions CI

### DIFF
--- a/.github/workflows/ci-bazel.yaml
+++ b/.github/workflows/ci-bazel.yaml
@@ -1,0 +1,17 @@
+name: Bazel
+on:
+  pull_request:
+  push:
+    branches: master
+jobs:
+  Build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - run: bazel build //...
+
+  Test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - run: bazel test //...

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,8 +1,0 @@
-name: Tests
-on: [pull_request]
-jobs:
-  RunBazelTests:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - run: bazel test //...

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,8 @@
+name: Tests
+on: [pull_request]
+jobs:
+  RunBazelTests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - run: bazel test //...


### PR DESCRIPTION
This currently just runs `bazel test //...` (... which does basically nothing) but is still a good place to start.