### PR TITLE
chore: fill out readme and make code a little less me-centric

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -18,7 +18,7 @@ genrule(
     name = "example_save",
     srcs = [],
     outs = ["world.json"],
-    cmd = "$(location //tools/new_game) -name jeshua > $@",
+    cmd = "$(location //tools/new_game) -name test > $@",
     tools = ["//tools/new_game"],
 )
 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,23 @@
 # wow-server-go
 
+This project aims to create golang-based server for World of Warcraft 1.12.1. This is for education purposes only.
+
+## Running the server
+
+The server is built/run using [bazel](https://bazel.build).
+
+1. `$ bazel run //:wow_server_go`
+2. Change the `realmlist.wtf` file in your game client to:
+
+```
+set realmlist 127.0.0.1:5000
+set patchlist 127.0.0.1:5000
+```
+
+3. Launch the game and enter the account name `test` and password `test`.
+
+## Running the tests
+
+Tests are also managed using bazel.
+
+- `$ bazel test //...`

--- a/server/world/data/static/starting_items.go
+++ b/server/world/data/static/starting_items.go
@@ -1,18 +1,25 @@
 package static
 
-var (
-	startingItems = map[string]map[string][]string{
-		"Warrior": {
-			"Human": {
-				"Recruit's Boots",
-				"Recruit's Pants",
-				"Recruit's Shirt",
-				"Worn Shortsword",
-				"Worn Wooden Shield",
-			},
+var startingItems = map[string]map[string][]string{
+	"Warrior": {
+		"Human": {
+			"Recruit's Boots",
+			"Recruit's Pants",
+			"Recruit's Shirt",
+			"Worn Shortsword",
+			"Worn Wooden Shield",
 		},
-	}
-)
+	},
+	"Paladin": {
+		"Human": {
+			"Recruit's Boots",
+			"Recruit's Pants",
+			"Recruit's Shirt",
+			"Worn Shortsword",
+			"Worn Wooden Shield",
+		},
+	},
+}
 
 // GetStartingItems is a utility which will return a mapping of equipment slot
 // to the item that should be in that slot.

--- a/tools/dbc_utils/dbc_data/ChrStartingStats.json
+++ b/tools/dbc_utils/dbc_data/ChrStartingStats.json
@@ -8,5 +8,15 @@
         "intellect": 4,
         "spirit": 4,
         "base_health": 50
+    },
+    {
+        "class": "Paladin",
+        "race": "Human",
+        "strength": 22,
+        "agility": 20,
+        "stamina": 22,
+        "intellect": 20,
+        "spirit": 21,
+        "base_health": 50
     }
 ]

--- a/tools/new_game/new_game.go
+++ b/tools/new_game/new_game.go
@@ -29,8 +29,8 @@ func main() {
 	var err error
 	config.Accounts[0].Character, err = initial_data.NewCharacter(
 		config,
-		"Jeshua",
-		static.RaceHuman, static.ClassWarrior, static.GenderMale,
+		"Leeroy Jenkins",
+		static.RaceHuman, static.ClassPaladin, static.GenderMale,
 		1, 1, 1, 1, 1)
 	if err != nil {
 		log.Fatalf("Failed to create character: %v", err)


### PR DESCRIPTION
The test data right now has been using my name as a placeholder. This PR makes it a little more generic and also fills out the `README.md` to describe how to run the code.

- `BUILD.bazel`: change default account name to `test`
- `README.md`: fill in README
- `server/world/data/static/starting_items.go`: add starting items for paladin
- `tools/dbc_utils/dbc_data/ChrStartingStats.json`: add starting stats for paladin
- `tools/new_game/new_game.go`: make the first character created [Leeroy Jenkins](https://www.youtube.com/watch?v=mLyOj_QD4a4)